### PR TITLE
fix cookie render for ci.yml

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,10 +12,15 @@
   "camel_name": "{{cookiecutter.plugin_slug.title().replace('-', '')}}",
   "project_short_description": "{{cookiecutter.verbose_name}}",
   "version": "0.1.0",
-  "open_source_license": ["Apache-2.0", "Not open source"],
-  "setup_local_mattermost_dev_env": ["Yes", "No"],
+  "open_source_license": [
+    "Apache-2.0",
+    "Not open source"
+  ],
+  "setup_local_mattermost_dev_env": [
+    "Yes",
+    "No"
+  ],
   "_copy_without_render": [
-    ".github/actions/setup-environment/action.yml",
-    ".github/workflows/ci.yml"
+    ".github/actions/setup-environment/action.yml"
   ]
 }


### PR DESCRIPTION
PR to fix issue where cookiecutter does not render github actions variables properly in `ci.yml`