### PR TITLE
Fix Mattermost Build

### DIFF
--- a/{{ cookiecutter.project_slug }}/development/Dockerfile-mattermost
+++ b/{{ cookiecutter.project_slug }}/development/Dockerfile-mattermost
@@ -1,7 +1,7 @@
 ARG MYSQL_VER=5.7
 FROM mysql:${MYSQL_VER}
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN yum -y update && yum install -y ca-certificates
 
 #
 # Configure SQL


### PR DESCRIPTION
This PR fixes the Mattermost container build process. It changes from apt-get to use yum as the base container changed for Mattermost to be RHEL/CentOS based instead of Debian. This also should ensure that any prompts during the update or install are accepted. Fixes #15.